### PR TITLE
[Feature] Privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,9 @@ let package = Package(
             targets: ["FHPropertyWrappers"]
         ),
     ],
-    dependencies: [],
     targets: [
         .target(
             name: "FHPropertyWrappers",
-            dependencies: [],
             resources: [.process("Resources")]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
     targets: [
         .target(
             name: "FHPropertyWrappers",
-            dependencies: []
+            dependencies: [],
+            resources: [.copy("Resources")]
         ),
         .testTarget(
             name: "FHPropertyWrappersTests",

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .target(
             name: "FHPropertyWrappers",
             dependencies: [],
-            resources: [.copy("Resources")]
+            resources: [.process("Resources")]
         ),
         .testTarget(
             name: "FHPropertyWrappersTests",

--- a/Sources/FHPropertyWrappers/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/FHPropertyWrappers/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/Sources/FHPropertyWrappers/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/FHPropertyWrappers/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds the soon mandatory privacy manifest file because this packages uses UserDefaults, per [Apple's docs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).