### PR TITLE
[Improvement] UserDefaults Access Reason

### DIFF
--- a/Sources/FHPropertyWrappers/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/FHPropertyWrappers/Resources/PrivacyInfo.xcprivacy
@@ -2,7 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
 	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>

--- a/Sources/FHPropertyWrappers/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/FHPropertyWrappers/Resources/PrivacyInfo.xcprivacy
@@ -11,7 +11,7 @@
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>CA92.1</string>
+				<string>C56D.1</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
This PR changes the UserDefaults access reason, wrapping is more accurate because this package does not use it for its own purposes.

Source: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401